### PR TITLE
Add Dockerfile for `docker-packer-ansible`

### DIFF
--- a/docker-packer-ansible/Dockerfile
+++ b/docker-packer-ansible/Dockerfile
@@ -11,6 +11,3 @@ RUN wget https://releases.hashicorp.com/packer/${PACKER_VERSION}/packer_${PACKER
 RUN apk update && \
     apk upgrade && \
     apk add ansible
-
-
-

--- a/docker-packer-ansible/Dockerfile
+++ b/docker-packer-ansible/Dockerfile
@@ -1,0 +1,16 @@
+FROM docker:20.10.6
+
+ARG PACKER_VERSION="1.7.2"
+
+# install packer
+RUN wget https://releases.hashicorp.com/packer/${PACKER_VERSION}/packer_${PACKER_VERSION}_linux_amd64.zip && \
+    unzip -o *.zip -d /usr/local/bin && \
+    rm *.zip
+
+# install ansible
+RUN apk update && \
+    apk upgrade && \
+    apk add ansible
+
+
+

--- a/docker-packer-ansible/README.md
+++ b/docker-packer-ansible/README.md
@@ -1,0 +1,11 @@
+# docker-packer-ansible
+
+This Dockerfile, based on Alpine Linux, contains the following:
+  
+  * docker  - v20.10.6
+  * ansible - (latest from Alpine Linux)
+  * packer  - v1.7.2
+
+## Use Case
+
+A potential use case for this Dockerfile might be leveraging Packer's [Docker builder](https://www.packer.io/docs/builders/docker) to build a Docker image using Ansible playbooks referenced from a Packer configuration.


### PR DESCRIPTION
## Description

This update will add a new `Dockerfile` to the repository: `docker-packer-ansible`.  The new image contains the tools necessary to build Docker images using Packer and Ansible.

At this time, the repository does not contain CI tooling.  This will come in a future enhancement, and the building/tagging/pushing of the image will be included at that time.
