### PR TITLE
Update README for `docker-packer-ansible` image to include build/push details

### DIFF
--- a/docker-packer-ansible/README.md
+++ b/docker-packer-ansible/README.md
@@ -9,3 +9,18 @@ This Dockerfile, based on Alpine Linux, contains the following:
 ## Use Case
 
 A potential use case for this Dockerfile might be leveraging Packer's [Docker builder](https://www.packer.io/docs/builders/docker) to build a Docker image using Ansible playbooks referenced from a Packer configuration.
+
+## Building and Pushing to Dockerhub
+
+To build:
+
+```
+docker build . -t msnook/docker-packer-ansible
+```
+
+To push:
+
+```
+docker login
+docker push msnook/docker-packer-ansible
+```


### PR DESCRIPTION
## Description

This update adds some additional details to the `README` for the `docker-packer-ansible` image; namely, instructions on how to build/push to Dockerhub.