### PR TITLE
Update to `docker-packer-ansible` image to install specific version of Ansible

### DIFF
--- a/docker-packer-ansible/Dockerfile
+++ b/docker-packer-ansible/Dockerfile
@@ -1,6 +1,14 @@
 FROM docker:20.10.6
 
 ARG PACKER_VERSION="1.7.2"
+ARG ANSIBLE_VERSION="2.9.21"
+
+# install necessary utilities
+RUN apk update && \
+    apk upgrade && \
+    apk add --update python3 py3-pip openssl ca-certificates && \
+    apk --update add --virtual build-dependencies python3-dev libffi-dev openssl-dev build-base && \
+    pip3 install --upgrade pip
 
 # install packer
 RUN wget https://releases.hashicorp.com/packer/${PACKER_VERSION}/packer_${PACKER_VERSION}_linux_amd64.zip && \
@@ -8,6 +16,8 @@ RUN wget https://releases.hashicorp.com/packer/${PACKER_VERSION}/packer_${PACKER
     rm *.zip
 
 # install ansible
-RUN apk update && \
-    apk upgrade && \
-    apk add ansible
+RUN CRYPTOGRAPHY_DONT_BUILD_RUST=1 pip3 install ansible==${ANSIBLE_VERSION}
+
+# clean up
+RUN apk del build-dependencies && \
+    rm -rf /var/cache/apk/* \

--- a/docker-packer-ansible/README.md
+++ b/docker-packer-ansible/README.md
@@ -3,7 +3,7 @@
 This Dockerfile, based on Alpine Linux, contains the following:
   
   * docker  - v20.10.6
-  * ansible - (latest from Alpine Linux)
+  * ansible - v2.9.21
   * packer  - v1.7.2
 
 ## Use Case


### PR DESCRIPTION
## Description

Previously, the `docker-packer-ansible` image would be created with the latest version of Ansible available in Alpine Linux.  However, this modification installs Ansible by way of `pip3`, which allows us to explicitly define a version we desire.

## Acceptance Validation

```
docker run --rm msnook/docker-packer-ansible ansible --version
ansible 2.9.21
```