### PR TITLE
Update README for `ansible-packer-terraform` to include docker tag details

### DIFF
--- a/ansible-packer-terraform/README.md
+++ b/ansible-packer-terraform/README.md
@@ -3,7 +3,7 @@
 This Dockerfile, based on Ubuntu, contains the following:
   
   * terraform  - v0.12.23
-  * ansible    - v2.9
+  * ansible    - v2.9.x
   * packer     - v1.7.2
   * aws cli    - v1.19.0
 
@@ -16,12 +16,20 @@ This Dockerfile is ideal for use as a one-stop-shop for primary tools needed in 
 To build:
 
 ```
-docker build . -t msnook/ansible-packer-terraform
+docker build . -t msnook/ansible-packer-terraform:latest
+```
+
+To tag using latest commit SHA:
+
+```
+tag=`git rev-parse --short HEAD`
+docker tag msnook/ansible-packer-terraform:latest msnook/ansible-packer-terraform:$tag
 ```
 
 To push:
 
 ```
 docker login
-docker push msnook/ansible-packer-terraform
+docker push msnook/ansible-packer-terraform:$tag
+docker push msnook/ansible-packer-terraform:latest (if desired)
 ```

--- a/docker-packer-ansible/README.md
+++ b/docker-packer-ansible/README.md
@@ -15,12 +15,20 @@ A potential use case for this Dockerfile might be leveraging Packer's [Docker bu
 To build:
 
 ```
-docker build . -t msnook/docker-packer-ansible
+docker build . -t msnook/docker-packer-ansible:latest
+```
+
+To tag using latest commit SHA:
+
+```
+tag=`git rev-parse --short HEAD`
+docker tag msnook/docker-packer-ansible:latest msnook/docker-packer-ansible:$tag
 ```
 
 To push:
 
 ```
 docker login
-docker push msnook/docker-packer-ansible
+docker push msnook/docker-packer-ansible:$tag
+docker push msnook/docker-packer-ansible:latest (if desired)
 ```


### PR DESCRIPTION
## Description

This update ensures that the `README` documentation includes details on tagging the images prior to pushing to Dockerhub.